### PR TITLE
Dockerfile: Use Debian as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.14
-# android-tools includes simg2img and img2simg
-RUN apk update
-RUN apk add zip android-tools brotli python3 py3-aiohttp file
+FROM debian:bullseye-slim
 
-RUN adduser -D -H gsitozip gsitozip
+RUN apt update && \
+    apt install zip brotli python3 python3-aiohttp file xz-utils -y
+
+RUN useradd -m -s /bin/sh gsitozip
 
 WORKDIR /usr/src/gsi2zip
 COPY --chown=gsitozip:gsitozip . .

--- a/web.py
+++ b/web.py
@@ -400,7 +400,8 @@ async def chmod_hack():
     await async_call(loop, "chmod 755 simg/img2simg")
 
 asyncio.run(chmod_hack())
-
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
 app = web.Application()
 app.add_routes(routes)
 web.run_app(app, port=os.environ.get("PORT", 8080))


### PR DESCRIPTION
Fix `unxz`: Busybox version of `unxz` doesn't support the -T option, so XZ imgs where not able to be decompressed correctly
